### PR TITLE
Set IgnoresException property to false so the layout will handle the …

### DIFF
--- a/src/log4net.Layout.Json/JsonLayout.cs
+++ b/src/log4net.Layout.Json/JsonLayout.cs
@@ -18,6 +18,17 @@ namespace log4net.Layout.Json
         {
         }
 
+        /// <summary>
+        /// IgnoresException. f this layout handles the exception object contained within LoggingEvent, then the layout should return false. Otherwise, if the layout ignores the exception object, then the layout should return true.
+        /// </summary>
+        public override bool IgnoresException
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public override void Format(TextWriter writer, LoggingEvent e)
         {
             var dic = new Dictionary<string, object>


### PR DESCRIPTION
…exceptions

In my experience, if this is not set to false exceptions will not be correctly formatted.
https://logging.apache.org/log4net/release/sdk/html/P_log4net_Layout_LayoutSkeleton_IgnoresException.htm